### PR TITLE
pallets: update tests in collator selection

### DIFF
--- a/pallets/collator-selection/src/mock.rs
+++ b/pallets/collator-selection/src/mock.rs
@@ -219,6 +219,7 @@ impl Config for Test {
 	type ValidatorIdOf = IdentityCollator;
 	type ValidatorRegistration = IsRegistered;
 	type WeightInfo = ();
+	type SessionLength = Period;
 }
 
 pub fn new_test_ext() -> sp_io::TestExternalities {
@@ -235,6 +236,7 @@ pub fn new_test_ext() -> sp_io::TestExternalities {
 		desired_candidates: 2,
 		candidacy_bond: 10,
 		invulnerables,
+		missing_blocks_threshold: 0,
 	};
 	let session = pallet_session::GenesisConfig::<Test> { keys };
 	pallet_balances::GenesisConfig::<Test> { balances }


### PR DESCRIPTION
- fix `register_as_candidate` API
- remove `should_not_kick_mechanism_too_few` test
- add `kick_3_times_to_add_blacklist` test

```
root@parachain:~/substrate-parachain-ssvm/pallets/collator-selection# cargo test
    Finished test [unoptimized + debuginfo] target(s) in 0.21s
     Running unittests (/root/substrate-parachain-ssvm/target/debug/deps/pallet_collator_selection-6c47cd2e00218f1c)

running 19 tests
test mock::__construct_runtime_integrity_test::runtime_integrity_tests ... ok
test tests::cannot_set_genesis_value_twice - should panic ... ok
test tests::cannot_register_as_candidate_if_invulnerable ... ok
test tests::cannot_register_as_candidate_if_keys_not_registered ... ok
test tests::it_should_set_invulnerables ... ok
test tests::register_as_candidate_works ... ok
test tests::basic_setup_works ... ok
test tests::fees_edgecases ... ok
test tests::cannot_register_as_candidate_if_poor ... ok
test tests::set_candidacy_bond ... ok
test tests::authorship_event_handler ... ok
test tests::cannot_register_dupe_candidate ... ok
test tests::cannot_unregister_candidate_if_too_few ... ok
test tests::cannot_register_candidate_if_too_many ... ok
test tests::leave_intent ... ok
test tests::set_desired_candidates_works ... ok
test tests::session_management_works ... ok
test tests::kick_mechanism ... ok
test tests::kick_3_times_to_add_blacklist ... ok

test result: ok. 19 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.03s

   Doc-tests pallet-collator-selection

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
```